### PR TITLE
Added debug log for install script output

### DIFF
--- a/lib/vector/installer.ex
+++ b/lib/vector/installer.ex
@@ -63,18 +63,18 @@ defmodule Vector.Installer do
     install = String.replace(@install, "{path}", path)
     install = String.to_charlist(install)
     # credo:disable-for-next-line
-    debug_output = :os.cmd(install)
-    IO.puts(debug_output)
-    validate!()
+    debug_info = :os.cmd(install)
+    validate!(debug_info)
   end
 
-  defp validate! do
+  defp validate!(debug_info) do
     case Vector.version() do
       {:ok, version} ->
         Logger.debug("Vector #{version} installed.")
         :ok
 
       :error ->
+        IO.puts(debug_info)
         raise RuntimeError, "Vector binary failed to install."
     end
   end

--- a/lib/vector/installer.ex
+++ b/lib/vector/installer.ex
@@ -63,7 +63,8 @@ defmodule Vector.Installer do
     install = String.replace(@install, "{path}", path)
     install = String.to_charlist(install)
     # credo:disable-for-next-line
-    :os.cmd(install)
+    debug_output = :os.cmd(install)
+    IO.puts(debug_output)
     validate!()
   end
 


### PR DESCRIPTION
I ran into issues with installing vector and in order to debug it I needed to see the output of the install script. This will by default print the output of the vector install script for help with debugging. 

One idea is to check first for `MIX_DEBUG` environment variable and only log if MIX_DEBUG=true | 1


I tested this locally by running on jetstream and updating the vector install file in the deps folder
```shell
mix deps.compile vector_agent --force  
```

Example of error state: 
```shell
mix deps.compile vector_agent --force                       [6:30:20]
==> vector_agent
06:30:21.479 [debug] Vector binary downloading...
                                   __   __  __
                                   \ \ / / / /
                                    \ V / / /
                                     \_/  \/

                                   V E C T O R
                                    Installer


--------------------------------------------------------------------------------
Website: https://vector.dev
Docs: https://vector.dev/docs/
Community: https://vector.dev/community/
--------------------------------------------------------------------------------

>>> Downloading Vector via https://packages.timber.io/vector/0.42.0/vector-0.42.0-arm64-apple-darwin.tar.gzcurl: (56) The requested URL returned error: 404
vector: installer for platform 'aarch64-apple-darwin' not found, this may be unsupported


== Compilation error in file lib/vector/installer.ex ==
** (RuntimeError) Vector binary failed to install.
    lib/vector/installer.ex:78: Vector.Installer.validate!/1
    (stdlib 6.2) lists.erl:2146: :lists.foldl/3
```

Example of a successful install: 
```shell
mix deps.compile vector_agent --force
==> vector_agent
Compiling 8 files (.ex)

06:35:32.243 [debug] Vector binary downloading...

06:35:37.269 [debug] Vector 0.44.0 installed.
Generated vector_agent app
```