### PR TITLE
Remove extraneous pattern match on`:exec.stop/1` call

### DIFF
--- a/lib/vector/agent.ex
+++ b/lib/vector/agent.ex
@@ -89,7 +89,7 @@ defmodule Vector.Agent do
 
   def terminate(message, agent) when message in [:normal, :shutdown] do
     :ok = Logger.log(agent, :info, "vector: Vector is stopping.")
-    :ok = :exec.stop(agent.os_pid)
+    :exec.stop(agent.os_pid)
     do_confirm_exit(agent)
     do_flush_messages(agent)
     :ok = Logger.log(agent, :info, "vector: Vector has stopped.")


### PR DESCRIPTION
Fixes MatchError when kill command fails during process termination. The `exec.stop(<pid>)` call is returning `{:error, ~c"pid not alive"}` and fails the pattern match. 

This change removes the extraneous pattern match and allows the rest of the code to complete. 

We've seen ~16k cases of this error in the last 30 days across the STG and DEV environment. 
Example error: 

https://cloudlogging.app.goo.gl/qeXsYrDo4WrLUabs6

https://movable-ink.sentry.io/organizations/movable-ink/issues/6751271449/?environment=prod&project=4508808170766336


There are actually two different errors that are happening inside of the vector code and I think that this will solve both of them. 

The two stacktraces: 

```stacktrace
GenServer #PID<0.151748.0> terminating
** (stop) :enoent
    (elixir 1.18.0) lib/system.ex:1114: System.cmd("kill", ["-0", "22842"], [stderr_to_stdout: true])
    (vector_agent 0.3.3) lib/vector/agent.ex:145: Vector.Agent.do_confirm_exit/1
    (vector_agent 0.3.3) lib/vector/agent.ex:93: Vector.Agent.terminate/2
    (stdlib 6.2) gen_server.erl:2393: :gen_server.try_terminate/3
    (stdlib 6.2) gen_server.erl:2594: :gen_server.terminate/10
    (stdlib 6.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
Last message: :shutdown
```

And 
```
** (MatchError) no match of right hand side value: {:error, ~c"pid not alive"}
    (vector_agent 0.3.3) lib/vector/agent.ex:92:in `Vector.Agent.terminate/2'
    (stdlib 6.2) gen_server.erl:2393:in `:gen_server.try_terminate/3'
    (stdlib 6.2) gen_server.erl:2594:in `:gen_server.terminate/10'
    (stdlib 6.2) proc_lib.erl:329:in `:proc_lib.init_p_do_apply/3'
```

The first error occurs when the `:gen_server.try_terminate/3` is called, this is defined https://github.com/erlang/otp/blob/master/lib/stdlib/src/gen_server.erl#L2478-L2491

```
try_terminate(#server_data{module = Mod}, State, Reason) ->
    case erlang:function_exported(Mod, terminate, 2) of
        true ->
            try
                {ok, Mod:terminate(Reason, State)}
            catch
                throw:R ->
                    {ok, R};
                Class:R:Stacktrace ->
                    {'EXIT', Class, R, Stacktrace}
            end;
        false ->
            {ok, ok}
    end.
```

The error is being generated by the `Mod:terminate(Reason, State)` function call which is actually a call back out to the agents terminate command `Vector.Agent.terminate/2`, which fails with the pattern match and is returned by the calling process. 